### PR TITLE
add skeleton loaders to prevent layout shift

### DIFF
--- a/next/src/components/EventCalendar/EventCalendarSkeleton.tsx
+++ b/next/src/components/EventCalendar/EventCalendarSkeleton.tsx
@@ -1,0 +1,25 @@
+export default function EventCalendarSkeleton() {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="skeleton h-10 w-28" />
+        <div className="flex gap-4">
+          <div className="skeleton h-10 w-20" />
+          <div className="skeleton h-10 w-20" />
+        </div>
+        <div className="skeleton h-10 w-20" />
+      </div>
+      <div className="grid w-full grid-cols-7 gap-4">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <div className="skeleton h-36 w-full" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/next/src/components/EventSelector/EventSelector.tsx
+++ b/next/src/components/EventSelector/EventSelector.tsx
@@ -6,11 +6,20 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useContext, useEffect, useState } from 'react';
 import { LuCalendarPlus } from 'react-icons/lu';
+import EventCalendarSkeleton from '../EventCalendar/EventCalendarSkeleton';
+import EventListSkeleton from '../EventsList/EventListSkeleton';
+import MobileCalendarSkeleton from '../MobileCalendar/MobileCalendarSkeleton';
 import './EventSelector.css';
-const EventCalendar = dynamic(() => import('../EventCalendar/EventCalendar'));
-const EventsList = dynamic(() => import('../EventsList/EventsList'));
+
+const EventCalendar = dynamic(() => import('../EventCalendar/EventCalendar'), {
+  loading: () => <EventCalendarSkeleton />,
+});
+const EventsList = dynamic(() => import('../EventsList/EventsList'), {
+  loading: () => <EventListSkeleton />,
+});
 const MobileCalendar = dynamic(
   () => import('../MobileCalendar/MobileCalendar'),
+  { loading: () => <MobileCalendarSkeleton /> },
 );
 
 interface EventSelectorProps {

--- a/next/src/components/EventsList/EventListSkeleton.tsx
+++ b/next/src/components/EventsList/EventListSkeleton.tsx
@@ -1,0 +1,18 @@
+export default function EventListSkeleton() {
+  return (
+    <div className="flex flex-col gap-12">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="flex flex-col gap-2">
+          <div className="skeleton h-10 w-36" />
+          <div className="flex flex-col gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <div className="skeleton h-28 w-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/next/src/components/MobileCalendar/MobileCalendarSkeleton.tsx
+++ b/next/src/components/MobileCalendar/MobileCalendarSkeleton.tsx
@@ -1,0 +1,27 @@
+export default function MobileCalendarSkeleton() {
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="skeleton h-8 w-14" />
+        <div className="skeleton h-8 w-20" />
+        <div className="skeleton h-8 w-14" />
+      </div>
+      <div className="mb-4 flex gap-4">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="skeleton h-6 w-full" />
+        ))}
+      </div>
+      <div className="grid w-full grid-cols-7 gap-4">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex gap-1">
+                <div className="skeleton h-16 w-full" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Please open an issue before submitting a pull request to ensure that your bugfix, feature, etc is accepted beforehand.

## Description

Adds loading skeletons to prevent layout shift on event page where components are lazyly loaded

## Related issues

_Check GitHub issue referencing [keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword):_

-   Closes #80 

## Screenshots (_optional_)

![image](https://github.com/luuppiry/luuppi-next/assets/26027985/4854abc2-baa0-4388-badb-a3c64489f0dc)

