### PR TITLE
Add alcohol meter to events

### DIFF
--- a/next/src/app/[lang]/(content-pages)/events/[slug]/page.tsx
+++ b/next/src/app/[lang]/(content-pages)/events/[slug]/page.tsx
@@ -16,7 +16,9 @@ import Image from 'next/image';
 import { redirect } from 'next/navigation';
 import Script from 'next/script';
 import { Suspense } from 'react';
+import { BiSolidDrink } from 'react-icons/bi';
 import { IoCalendarOutline, IoLocationOutline } from 'react-icons/io5';
+import { MdNoDrinks } from 'react-icons/md';
 import { PiImageBroken } from 'react-icons/pi';
 
 interface EventProps {
@@ -134,6 +136,20 @@ export default async function Event(props: EventProps) {
                   }
                 </p>
               </div>
+              {event.data.attributes['Alcohol'] && (
+                <div className="flex items-center">
+                  <div className="mr-2 flex items-center justify-center rounded-full bg-primary-400 p-2 text-white">
+                    {event.data.attributes['Alcohol'] === 'no_alcohol' ? (
+                      <MdNoDrinks className="shrink-0 text-2xl" />
+                    ) : (
+                      <BiSolidDrink className="shrink-0 text-2xl" />
+                    )}
+                  </div>
+                  <p className="line-clamp-2 font-normal">
+                    {dictionary.pages_events[event.data.attributes['Alcohol']]}
+                  </p>
+                </div>
+              )}
             </div>
           </div>
           {hasRegistration && (

--- a/next/src/locales/en.json
+++ b/next/src/locales/en.json
@@ -298,7 +298,10 @@
     "unanswered_questions": "Unanswered questions!",
     "unanswered_questions_description": "One or more of your unpaid reservations require additional information. Please respond to the reservation questions by pressing the \"Details\" button and completing the questions. Once you have answered the questions for all your unpaid reservations, you can proceed to make the payment.",
     "no_quota": "There is no quota for your role in this event.",
-    "show_participants": "Show participants"
+    "show_participants": "Show participants",
+    "no_alcohol": "The event is alcohol-free.",
+    "some_alcohol": "You can drink alcohol if you wish, but drinking is not the main point of the event. You can also participate in the event without alcohol.",
+    "full_alcohol": "Alcohol is a central part of the event, for example as part of the programme. You can also participate in the event without alcohol."
   },
   "pages_404": {
     "title": "Page not found",

--- a/next/src/locales/fi.json
+++ b/next/src/locales/fi.json
@@ -298,7 +298,10 @@
     "unanswered_questions": "Vastaamattomia kysymyksiä!",
     "unanswered_questions_description": "Yksi tai useampi maksamaton varauksesi vaatii lisätietoja. Vastaa varauksen kysymyksiin painamalla \"Lisätiedot\"-nappia ja täyttämällä kysymykset. Kun olet vastannut kaikkien maksamattomien varauksiesi kysymyksiin, voit maksaa varaukset.",
     "no_quota": "Roolillesi ei ole kiintiötä tässä tapahtumassa.",
-    "show_participants": "Näytä osallistujat"
+    "show_participants": "Näytä osallistujat",
+    "no_alcohol": "Tapahtuma on alkoholiton.",
+    "some_alcohol": "Tapahtumassa voi halutessaan käyttää alkoholia, mutta juominen ei ole pääpointti. Tapahtumaan voi myös osallistua alkoholittomana.",
+    "full_alcohol": "Tapahtumassa alkoholin käyttö on keskeisessä asemassa esimerkiksi osana ohjelmaa. Tapahtumaan voi myös osallistua alkoholittomana."
   },
   "pages_404": {
     "title": "Sivua ei löytynyt",

--- a/next/src/types/contentTypes.d.ts
+++ b/next/src/types/contentTypes.d.ts
@@ -1180,6 +1180,9 @@ export interface ApiEventEvent extends Schema.CollectionType {
     NameEn: Attribute.String & Attribute.Required;
     DescriptionEn: Attribute.Blocks & Attribute.Required;
     ImageEn: Attribute.Media<'images'>;
+    Alcohol: Attribute.Enumeration<
+      ['no_alcohol', 'some_alcohol', 'full_alcohol']
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/strapi/src/api/event/content-types/event/schema.json
+++ b/strapi/src/api/event/content-types/event/schema.json
@@ -72,6 +72,15 @@
       "allowedTypes": [
         "images"
       ]
+    },
+    "Alcohol": {
+      "type": "enumeration",
+      "enum": [
+        "no_alcohol",
+        "some_alcohol",
+        "full_alcohol"
+      ],
+      "required": false
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1180,6 +1180,9 @@ export interface ApiEventEvent extends Schema.CollectionType {
     NameEn: Attribute.String & Attribute.Required;
     DescriptionEn: Attribute.Blocks & Attribute.Required;
     ImageEn: Attribute.Media<'images'>;
+    Alcohol: Attribute.Enumeration<
+      ['no_alcohol', 'some_alcohol', 'full_alcohol']
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
## Description

vetomittari lisätty'd

Strapissa on nyt tapahtumaa luodessa vapaaehtoinen valinta kolmesta eri alkoholitasosta tapahtumalle. Jos ei valitse mitään niin ei näy tota alkoholiriviä tapahtuman tiedoissa (eli vanhoissa tapahtumissa ei sit oo mitään).

## Related issues

-   Closes #197 

## Screenshots (_optional_)

![image](https://github.com/user-attachments/assets/451a2c64-ea3a-4030-a7e7-d4120c81fffe)
![image](https://github.com/user-attachments/assets/b52aaa45-569b-4975-8e4c-ca4e37af4719)

