### PR TITLE
Fix extra day on desktop event calendar

### DIFF
--- a/next/src/components/EventCalendar/EventCalendar.tsx
+++ b/next/src/components/EventCalendar/EventCalendar.tsx
@@ -111,7 +111,6 @@ export default function EventCalendar({
                 }
               : {
                   weekday: 'long',
-                  day: 'numeric',
                 }
           }
           dayMaxEventRows={4}


### PR DESCRIPTION
Esim. 

`new Intl.DateTimeFormat('fi', { weekday: 'long', day: 'numeric' }).format(new Date())` -> tiistaina 9.
`new Intl.DateTimeFormat('fi', { weekday: 'long' }).format(new Date())` -> tiistai

closes #153