### PR TITLE
Display events lasting to morning as single day

### DIFF
--- a/next/src/components/EventCalendar/EventCalendar.tsx
+++ b/next/src/components/EventCalendar/EventCalendar.tsx
@@ -140,7 +140,15 @@ export default function EventCalendar({
             meridiem: false,
             hour12: false,
           }}
-          events={events}
+          events={events.map((event) => {
+            // Force multi-day events to display as block elements since `nextDayThreshold`
+            // prevents FullCalendar from automatically detecting them as multi-day.
+            if (event.start.getDate() != event.end.getDate()) {
+              (event as Event & { display: string }).display = 'block';
+            }
+
+            return event;
+          })}
           headerToolbar={
             !isSmallDesktop
               ? {
@@ -158,6 +166,7 @@ export default function EventCalendar({
           initialDate={new Date(currentYear, currentMonth, 1)}
           initialView={'dayGridMonth'}
           locale={lang === 'fi' ? fiLocale : ''}
+          nextDayThreshold="06:00"
           plugins={[dayGridPlugin, timeGridPlugin]}
           slotLabelFormat={{
             hour: 'numeric',


### PR DESCRIPTION
## Description

Näyttää kalenterissa aamuyöhön kestävät tapahtumat yksipäiväisinä. 

## Related issues

-   Closes #227

## Screenshots

Uusi:
<img width="679" height="121" alt="Screenshot 2025-10-12 at 14 00 20" src="https://github.com/user-attachments/assets/776ae6d5-d969-4c56-abb8-9a62202c55f9" />

Vanha:
<img width="679" height="121" alt="Screenshot 2025-10-12 at 14 00 25" src="https://github.com/user-attachments/assets/43418165-c6e4-49f5-8401-782a5f00dde3" />
