### PR TITLE
fix: always start week on monday

### DIFF
--- a/next/src/components/MobileCalendar/MobileCalendar.tsx
+++ b/next/src/components/MobileCalendar/MobileCalendar.tsx
@@ -17,9 +17,8 @@ const getDaysOfWeek = (locale: SupportedLanguage) => {
     );
   }
 
-  if (locale === 'fi') {
-    daysOfWeek.push(daysOfWeek.shift());
-  }
+  // Always start with Monday regardless of locale
+  daysOfWeek.push(daysOfWeek.shift());
 
   return daysOfWeek;
 };
@@ -46,17 +45,12 @@ const groupEventsByStartDate = (events: Event[]): Record<string, Event[]> =>
       {} as Record<string, Event[]>,
     );
 
-const generateMonthGrid = (
-  year: number,
-  month: number,
-  locale: SupportedLanguage,
-) => {
+const generateMonthGrid = (year: number, month: number) => {
   const firstDayOfMonth = new Date(year, month, 1).getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
 
-  const offset = locale === 'fi' ? -1 : 0;
-  let adjustedFirstDay = (firstDayOfMonth + offset) % 7;
-  if (adjustedFirstDay < 0) adjustedFirstDay += 7;
+  // Always use Monday as first day of week (adjust Sunday from 0 to 6)
+  const adjustedFirstDay = (firstDayOfMonth + 6) % 7;
 
   const grid = [];
   let dayCounter = 1;
@@ -110,8 +104,8 @@ export default function MobileCalendar({
 
   const daysOfWeek = useMemo(() => getDaysOfWeek(lang), [lang]);
   const monthGrid = useMemo(
-    () => generateMonthGrid(currentYear, currentMonth, lang),
-    [currentYear, currentMonth, lang],
+    () => generateMonthGrid(currentYear, currentMonth),
+    [currentYear, currentMonth],
   );
   const groupedEvents = useMemo(() => groupEventsByStartDate(events), [events]);
 


### PR DESCRIPTION
## Description

Jos kielenä on englanti, kalenteri näyttää viikon alkavaksi sunnuntaista. Pidetään maanantai kerta Suomessa ollaan myös englannille.

## Related issues

#229 

## Screenshots (_optional_)

Vanha:

<img width="379" height="251" alt="Screenshot 2025-10-22 at 0 53 08" src="https://github.com/user-attachments/assets/5c5a80e4-3037-4dcb-9804-a4a9ebc47042" />

Uusi:

<img width="379" height="251" alt="Screenshot 2025-10-22 at 1 02 27" src="https://github.com/user-attachments/assets/f4aa2c16-23fd-4b64-9830-2e657fe52e2b" />